### PR TITLE
おみくじ取得APIを追加

### DIFF
--- a/backend/api/main_db.py
+++ b/backend/api/main_db.py
@@ -2,12 +2,16 @@ from fastapi import FastAPI
 from .db import engine, SessionLocal
 from .models import Base, Omikuji
 
+
 app = FastAPI()
 
 # DBテーブル作成
 Base.metadata.create_all(bind=engine)
 
 def seed_omikuji():
+    from .routers.omikuji import router as omikuji_router
+    app.include_router(omikuji_router)
+    
     db = SessionLocal()
     try:
         if db.query(Omikuji).count() > 0:

--- a/backend/api/routers/omikuji.py
+++ b/backend/api/routers/omikuji.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from ..db import SessionLocal
+from ..models import Omikuji
+
+router = APIRouter(prefix="/omikuji", tags=["omikuji"])
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.get("/random")
+def get_random_omikuji(db: Session = Depends(get_db)):
+    row = db.query(Omikuji).order_by(func.random()).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="No omikuji found")
+    return {"id": row.id, "name": row.name}
+
+
+@router.get("/count")
+def count_omikuji(db: Session = Depends(get_db)):
+    c = db.query(Omikuji).count()
+    return {"count": c}


### PR DESCRIPTION
## やったこと
- おみくじ用データベース（id, name のみ）を作成
- SQLite + SQLAlchemy を用いたテーブル定義を追加
- おみくじをランダムで取得する API を実装（GET /omikuji/random）
- おみくじの件数を取得する API を実装（GET /omikuji/count）
- DBのみ動作確認できる構成（AI処理とは分離）

## 補足
- 現時点では「大吉〜大凶」のデータを保持するシンプルな構成
- ルーティングは `/omikuji` 配下にまとめており、今後の拡張（結果文言追加など）を想定
- チームメンバーの AI / モーション処理コードには影響しない形で実装


